### PR TITLE
Build in dev mode by default

### DIFF
--- a/src/notebook.ts
+++ b/src/notebook.ts
@@ -1,3 +1,0 @@
-import './nb-public-path';
-
-export * from './index';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ module.exports = {
   },
   bail: true,
   devtool: 'source-map',
-  mode: 'production',
+  mode: 'development',
   module: {
     rules: [
       { test: /\.css$/, use: ['style-loader', 'css-loader'] },


### PR DESCRIPTION
This helps reduce the build time.

`build:prod` still builds in production mode.

Also remove an unused file.