### PR TITLE
Add missing default_url

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,6 +60,7 @@ class ExampleHandler(
 class ExampleApp(LabServerApp):
 
     extension_url = '/example'
+    default_url = '/example'
     app_url = "/example"
     load_other_extensions = False
     name = __name__


### PR DESCRIPTION
So that `python main.py` goes to the right URL directly