### PR TITLE
Minor link fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Create a new repo using this cookiecutter:
 ```bash
 pip install cookiecutter
 
-cookiecutter https://github.com/jtpio/jupyterlab-app-template
+cookiecutter https://github.com/jupyterlab-contrib/jupyterlab-app-template
 ```
 
 Follow the instructions in the README.md of the generated project to have your

--- a/{{cookiecutter.github_project_name}}/README.md
+++ b/{{cookiecutter.github_project_name}}/README.md
@@ -41,7 +41,7 @@ Since this template uses the same plugin system as the one used in JupyterLab, a
 
 ### Add the dependency
 
-The first step is to add the dependency to the `package.json`. Here using the [jupyterlab-plugin-graph](https://github.com/jtpio/jupyterlab-plugin-graph) JupyterLab extension available on npm:
+The first step is to add the dependency to the `package.json`. Here using the [jupyterlab-plugin-graph](https://github.com/jupyterlab-contrib/jupyterlab-plugin-graph) JupyterLab extension available on npm:
 
 ```diff
 --- a/package.json


### PR DESCRIPTION
Spotted two links that should be updated to point to https://github.com/jupyterlab-contrib