### PR TITLE
Fix Python 3.10 on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.10]
+        python: ["3.10"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Looks like it would run on 3.1 otherwise:

![image](https://user-images.githubusercontent.com/591645/166700275-f5011e3d-3c2d-4b64-8df9-fd03780c9cb8.png)
